### PR TITLE
Fix icon quality

### DIFF
--- a/lib/AndroidAppBundleInfo.js
+++ b/lib/AndroidAppBundleInfo.js
@@ -72,6 +72,35 @@
       })(this));
     };
 
+    // TODO : fix that !
+    AndroidAppBundleInfo.prototype.getIconFile = function(callback) {
+      var _this = this;
+
+      var lookupOrdered = [
+        "**/mipmap-xxxhdpi*/ic_launcher.png",
+        "**/drawable-xxxhdpi*/ic_launcher.png",
+        "**/mipmap-xxhdpi*/ic_launcher.png",
+        "**/drawable-xxhdpi*/ic_launcher.png",
+        "**/mipmap-xhdpi*/ic_launcher.png",
+        "**/drawable-xhdpi*/ic_launcher.png",
+        "**/mipmap-hdpi*/ic_launcher.png",
+        "**/drawable-hdpi*/ic_launcher.png",
+        "**/mipmap-*/ic_launcher.png",
+        "**/drawable-*/ic_launcher.png"
+      ];
+
+      function find(index, cb){
+        if(!lookupOrdered[index])
+          return cb(new Error("Icon not found"));
+
+        let path = lookupOrdered[index];
+        return _this.findFileStream(path, function(err, datas) {
+          if(err) return find(index+1, cb);
+          else return cb(null, datas);
+        });
+      }
+    };
+
     AndroidAppBundleInfo.prototype.getIdentifier = function() {
       var ref, ref1;
       return (ref = this._info) != null ? (ref1 = ref.manifest) != null ? ref1["package"] : void 0 : void 0;

--- a/lib/AndroidAppBundleInfo.js
+++ b/lib/AndroidAppBundleInfo.js
@@ -72,7 +72,7 @@
       })(this));
     };
 
-    // TODO : fix that !
+
     AndroidAppBundleInfo.prototype.getIconFile = function(callback) {
       var _this = this;
 
@@ -93,12 +93,13 @@
         if(!lookupOrdered[index])
           return cb(new Error("Icon not found"));
 
-        let path = lookupOrdered[index];
+        var path = lookupOrdered[index];
         return _this.findFileStream(path, function(err, datas) {
-          if(err) return find(index+1, cb);
-          else return cb(null, datas);
+          return (err) ? find(index+1, cb) : cb(null, datas);
         });
       }
+
+      find(0, callback);
     };
 
     AndroidAppBundleInfo.prototype.getIdentifier = function() {


### PR DESCRIPTION
Hi,

In my project I saw that the icon retrieve but the package was blury because you get the first 'hdpi' folder you find.
I add a complete lookup into differents folders to improve the extracted icon quality.

Again, I just did the JS and I will let you do the coffee one... hehe
I have some deadlines on my project, do you think you will be able to merge my PR in the weekend ?

Thank you.

PS : I test the code and one test don't pass, probably you are aware of it but here it is the log : 

```
1) ios should load and parse Info.plist from stream:
     Uncaught TypeError: Object #<Object> has no method 'inflateRawSync'
      at module.exports.revert.revertCgBIBuffer (node_modules/cgbi-to-png/index.js:70:29)
      at node_modules/cgbi-to-png/index.js:26:16
      at node_modules/stream-to-buffer/node_modules/stream-to/index.js:39:7
      at ReadStream.onEnd (node_modules/stream-to-buffer/node_modules/stream-to/index.js:18:5)
      at _stream_readable.js:929:16

```
