### PR TITLE
Support dynamic name of icons for iOS

### DIFF
--- a/lib/iOSAppBundleInfo.js
+++ b/lib/iOSAppBundleInfo.js
@@ -114,7 +114,7 @@
 
       function lookupType(origin, lookup, cb) {
         if(origin && origin.CFBundlePrimaryIcon && origin.CFBundlePrimaryIcon.CFBundleIconFiles) {
-          origin.CFBundlePrimaryIcon.CFBundleIconFiles.forEach(e => {
+          origin.CFBundlePrimaryIcon.CFBundleIconFiles.forEach(function(e) {
             lookup = lookup.concat(createSubNames(e, ""));
           });
           

--- a/lib/iOSAppBundleInfo.js
+++ b/lib/iOSAppBundleInfo.js
@@ -86,15 +86,61 @@
     };
 
     iOSAppBundleInfo.prototype.getIconFile = function(callback) {
-      return this.findFileStream('Payload/*.app/AppIcon60x60@*.png', function(err, stream) {
-        if (err) {
-          return callback(err);
-        }
-        if (!stream) {
-          return callback();
-        }
-        return cgbiToPng(stream, callback);
-      });
+      if(!this._info)
+        return callback(new Error("No plist found"));
+
+      var _plist = this._info.plist;
+      var self = this;
+      var lookupIphone = [];
+      var lookupIpad = [];
+
+      if(_plist.CFBundleIcons && _plist.CFBundleIcons.CFBundlePrimaryIcon && _plist.CFBundleIcons.CFBundlePrimaryIcon.CFBundleIconFiles) {
+        _plist.CFBundleIcons.CFBundlePrimaryIcon.CFBundleIconFiles.forEach(e => {
+          lookupIphone = lookupIphone.concat(createSubNames(e));
+        });
+      }
+      
+      if(_plist['CFBundleIcons~ipad'] && _plist['CFBundleIcons~ipad'].CFBundlePrimaryIcon && _plist['CFBundleIcons~ipad'].CFBundlePrimaryIcon.CFBundleIconFiles) {
+        _plist['CFBundleIcons~ipad'].CFBundlePrimaryIcon.CFBundleIconFiles.forEach(e => {
+          lookupIpad = lookupIpad.concat(createSubNames(e, "~ipad"));
+        });
+      }
+      
+      function createSubNames(initial, endname) {
+        endname = endname || "";
+        return [
+          initial + "@3x"+endname+".png",
+          initial + "@2x"+endname+".png"
+          // initial + endname+".png" 
+        ];
+      }
+
+      function find(index, isIphone, cb) {
+        var name = "*60x60@*.png";
+        var next = true;
+
+        if(isIphone && lookupIphone[index])
+          name = lookupIphone[index];
+        else if(isIphone)
+          return find(lookupIpad.length-1, false, cb);
+        else if(lookupIpad[index])
+          name = lookupIpad[index];
+        else
+          next = false;
+
+        self.findFileStream('Payload/*.app/' + name, function(err, stream) {
+          if (err && next)
+            return find(index - 1, isIphone, cb);
+          if (!next) 
+            return cb(new Error("No icon found"));
+
+          if (!stream) 
+            return cb();
+          return cgbiToPng(stream, cb);
+        });
+      }
+      
+      find(lookupIphone.length-1, true, callback);
     };
 
     iOSAppBundleInfo.prototype.getIdentifier = function() {

--- a/lib/iOSAppBundleInfo.js
+++ b/lib/iOSAppBundleInfo.js
@@ -91,56 +91,43 @@
 
       var _plist = this._info.plist;
       var self = this;
-      var lookupIphone = [];
-      var lookupIpad = [];
 
-      if(_plist.CFBundleIcons && _plist.CFBundleIcons.CFBundlePrimaryIcon && _plist.CFBundleIcons.CFBundlePrimaryIcon.CFBundleIconFiles) {
-        _plist.CFBundleIcons.CFBundlePrimaryIcon.CFBundleIconFiles.forEach(e => {
-          lookupIphone = lookupIphone.concat(createSubNames(e));
-        });
-      }
-      
-      if(_plist['CFBundleIcons~ipad'] && _plist['CFBundleIcons~ipad'].CFBundlePrimaryIcon && _plist['CFBundleIcons~ipad'].CFBundlePrimaryIcon.CFBundleIconFiles) {
-        _plist['CFBundleIcons~ipad'].CFBundlePrimaryIcon.CFBundleIconFiles.forEach(e => {
-          lookupIpad = lookupIpad.concat(createSubNames(e, "~ipad"));
-        });
-      }
-      
       function createSubNames(initial, endname) {
-        endname = endname || "";
         return [
           initial + "@3x"+endname+".png",
           initial + "@2x"+endname+".png"
-          // initial + endname+".png" 
         ];
       }
 
-      function find(index, isIphone, cb) {
-        var name = "*60x60@*.png";
-        var next = true;
+      function find(index, lookup, cb) {
+        if(!lookup[index])
+          return cb(new Error("Icon not found"));
 
-        if(isIphone && lookupIphone[index])
-          name = lookupIphone[index];
-        else if(isIphone)
-          return find(lookupIpad.length-1, false, cb);
-        else if(lookupIpad[index])
-          name = lookupIpad[index];
-        else
-          next = false;
-
-        self.findFileStream('Payload/*.app/' + name, function(err, stream) {
-          if (err && next)
-            return find(index - 1, isIphone, cb);
-          if (!next) 
-            return cb(new Error("No icon found"));
-
+        self.findFileStream('Payload/*.app/' + lookup[index], function(err, stream) {
+          if (err)
+            return find(index - 1, lookup, cb);
           if (!stream) 
             return cb();
           return cgbiToPng(stream, cb);
         });
       }
-      
-      find(lookupIphone.length-1, true, callback);
+
+      function lookupType(origin, lookup, cb) {
+        if(origin && origin.CFBundlePrimaryIcon && origin.CFBundlePrimaryIcon.CFBundleIconFiles) {
+          origin.CFBundlePrimaryIcon.CFBundleIconFiles.forEach(e => {
+            lookup = lookup.concat(createSubNames(e, ""));
+          });
+          
+          return find(lookup.length-1, lookup, cb);
+        }
+        return cb(new Error("No icons found in plist for this type"));
+      }
+
+      lookupType(_plist.CFBundleIcons, [], function(err, datas) {
+        if(err)
+          return lookupType(_plist['CFBundleIcons~ipad'], ["*60x60@*.png"], callback);
+        return callback(err, datas);
+      });
     };
 
     iOSAppBundleInfo.prototype.getIdentifier = function() {

--- a/test/ios.js
+++ b/test/ios.js
@@ -45,7 +45,7 @@ describe('ios',function(){
         },done);
     })
 
-     it.only('should load and get the icon from ipa using the plist',function(done){
+    it('should load and get the icon from ipa using the plist',function(done){
         this.timeout(5000);
         async.forEach(files,function(file,cb){
             var abi = new AppBundleInfo.iOS(file.file);

--- a/test/ios.js
+++ b/test/ios.js
@@ -5,7 +5,8 @@ var async = require('async');
 
 var files = [
     {file:__dirname+'/test.ipa',version:'0.1.2',name:'map-viewer'},
-    {file:__dirname+'/test2.ipa',version:'1.3.21',name:'ci-test-app'}
+    {file:__dirname+'/test2.ipa',version:'1.3.21',name:'ci-test-app'},
+    {file:__dirname+'/test3.ipa',version:'1.0.6',name:'ToitsAtlantiques'}
 ]
 
 describe('ios',function(){
@@ -41,6 +42,22 @@ describe('ios',function(){
                     assert.ifError(err);
                     cb();
                 })
+            });
+        },done);
+    })
+
+     it.only('should load and get the icon from file',function(done){
+        this.timeout(5000);
+        async.forEach(files,function(file,cb){
+            var abi = new AppBundleInfo.iOS(file.file);
+
+            abi.getPlist(function(err, data){
+                if(err)return cb(err);
+
+                abi.getIconFile(function(err, streamIcon) {
+                    if(err) return cb(new Error("Cannot read icon from this iOS package"));
+                    cb();
+                });
             });
         },done);
     })

--- a/test/ios.js
+++ b/test/ios.js
@@ -5,8 +5,7 @@ var async = require('async');
 
 var files = [
     {file:__dirname+'/test.ipa',version:'0.1.2',name:'map-viewer'},
-    {file:__dirname+'/test2.ipa',version:'1.3.21',name:'ci-test-app'},
-    {file:__dirname+'/test3.ipa',version:'1.0.6',name:'ToitsAtlantiques'}
+    {file:__dirname+'/test2.ipa',version:'1.3.21',name:'ci-test-app'}
 ]
 
 describe('ios',function(){
@@ -46,7 +45,7 @@ describe('ios',function(){
         },done);
     })
 
-     it.only('should load and get the icon from file',function(done){
+     it.only('should load and get the icon from ipa using the plist',function(done){
         this.timeout(5000);
         async.forEach(files,function(file,cb){
             var abi = new AppBundleInfo.iOS(file.file);


### PR DESCRIPTION
Hi,

I got a problem using an IPA which has an icon name generate at compile time. 
I edit your code to support this case.

The name of the icons are retrieved from the PList directly and I generate differents string name (with @3x and @2x).
By default the code will lookup for iPhone icons first then iPad. If nothing is found it will try to get `*60x60@*.png`.

As always I did the JS script, I let you the pleasure to do the CoffeeScript :)
I added a small test in test/ios.js too.

Have a nice day,
Spoke.
